### PR TITLE
Neatens up buttons

### DIFF
--- a/src/wagtail_rangefilter/templates/wagtail_rangefilter/date_filter.html
+++ b/src/wagtail_rangefilter/templates/wagtail_rangefilter/date_filter.html
@@ -12,8 +12,8 @@
             <input type="hidden" id="{{ choice.system_name }}-query-string" value="{{ choice.query_string }}">
         {% endfor %}
         <div>
-            <input type="submit" class="button" value="{% translate 'Search' %}">
-            <input type="reset" class="button" value="{% translate 'Reset' %}">
+            <button value="{% translate 'Search' %}" type="submit" class="button">{% translate 'Search' %}</button>
+            <button value="{% translate 'Reset' %}" type="reset" class="button button-secondary">{% translate 'Reset' %}</button>
         </div>
     </form>
 </div>


### PR DESCRIPTION
Just noticed the buttons were a little off in the UI, this PR swaps `inputs` for `buttons` and changes classes for the reset button to look 'secondary':

Before:

![Screenshot from 2022-12-05 13-00-28](https://user-images.githubusercontent.com/2128707/205644261-0f52f058-a4a3-479d-a8a5-a1408a88fdad.png)


After:

![Screenshot 2022-12-05 at 13-00-53 Wagtail - Enquiry form submissions](https://user-images.githubusercontent.com/2128707/205644279-73afa4db-ee2b-489d-84e8-79062051813c.png)


Also, the Wagtail style guide suggests to use `buttons` rather than `inputs` here.

![image](https://user-images.githubusercontent.com/2128707/205644080-df7a1c1b-1961-4449-92a3-153eb8f00c2b.png)
