### PR TITLE
Wagtail >= 5.2 upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
--
+- Added support Wagtail 5.1 (by @lparsons396)
 
 ## [0.2.0] - 2023-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Added support Wagtail 5.1 (by @lparsons396)
+- Added support Wagtail 5.1, 5.2 (by @lparsons396, @katdom13)
+- Drop tests for Wagtail 4.2, 5.0 as they have reached EOL (@katdom13)
 
 ## [0.2.0] - 2023-07-31
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Integrates [django-admin-rangefilter](https://pypi.org/project/django-admin-rang
 
 - Python 3.8, 3.9, 3.10, 3.11
 - Django 3.2, 4.1, 4.2
-- Wagtail 4.1, 4.2, 5.0
+- Wagtail 4.1, 4.2, 5.0, 5.1
 
 ## Installation
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,9 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.8,3.9,3.10}-django{3.2,4.1}-wagtail{4.1,4.2,5.0,5.1}-{sqlite,postgres}
-    python{3.11}-django{4.1,4.2}-wagtail{5.0,5.1}-{sqlite,postgres}
+    python{3.8,3.9,3.10}-django{3.2,4.1}-wagtail{4.1,5.1,5.2}-{sqlite,postgres}
+    python3.11-django4.1-wagtail{4.1,5.1,5.2}-{sqlite,postgres}
+    python3.11-django4.2-wagtail{5.1,5.2}-{sqlite,postgres}
     flake8
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.8,3.9,3.10}-django{3.2,4.1}-wagtail{4.1,4.2,main}-{sqlite,postgres}
-    python{3.11}-django{4.1,4.2}-wagtail{5.0,main}-{sqlite,postgres}
+    python{3.8,3.9,3.10}-django{3.2,4.1}-wagtail{4.1,4.2,5.0,5.1,main}-{sqlite,postgres}
+    python{3.11}-django{4.1,4.2}-wagtail{5.0,5.1,main}-{sqlite,postgres}
     flake8
 
 [flake8]
@@ -42,6 +42,7 @@ deps =
     wagtail4.1: wagtail>=4.1,<4.2
     wagtail4.2: wagtail>=4.2,<5.0
     wagtail5.0: wagtail>=5.0,<5.1
+    wagtail5.1: wagtail>=5.1,<5.2
     wagtailmain: git+https://github.com/wagtail/wagtail.git
 
     postgres: psycopg2>=2.6

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.8,3.9,3.10}-django{3.2,4.1}-wagtail{4.1,4.2,5.0,5.1,main}-{sqlite,postgres}
-    python{3.11}-django{4.1,4.2}-wagtail{5.0,5.1,main}-{sqlite,postgres}
+    python{3.8,3.9,3.10}-django{3.2,4.1}-wagtail{4.1,4.2,5.0,5.1}-{sqlite,postgres}
+    python{3.11}-django{4.1,4.2}-wagtail{5.0,5.1}-{sqlite,postgres}
     flake8
 
 [flake8]
@@ -43,6 +43,8 @@ deps =
     wagtail4.2: wagtail>=4.2,<5.0
     wagtail5.0: wagtail>=5.0,<5.1
     wagtail5.1: wagtail>=5.1,<5.2
+
+    ; The current Wagtail version for main is 5.1.x, which is deprecates the wagtail.contrib.modeladmin module
     wagtailmain: git+https://github.com/wagtail/wagtail.git
 
     postgres: psycopg2>=2.6


### PR DESCRIPTION
## Wagtail 5.2 ([See release notes](https://docs.wagtail.org/en/stable/releases/5.2.html))

This includes Wagtail 5.1 and 5.2 support in testing.

NB: Modeladmin will soon be deprecated, so while this still works as things stand, it might be worth looking into either the use of [wagtail-modeladmin](https://github.com/wagtail-nest/wagtail-modeladmin) or [Snippets](https://docs.wagtail.org/en/stable/reference/contrib/modeladmin/migrating_to_snippets.html#convert-modeladmin-class-to-snippetviewset)