### PR TITLE
Updated tests and README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
--
+- Added support Wagtail 5.1 (by @lparsons396)
 
 ## [0.2.0] - 2023-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Added support Wagtail 5.1 (by @lparsons396)
+- Added support Wagtail 5.1, 5.2 (by @lparsons396, @katdom13)
+- Drop tests for Wagtail 4.2, 5.0 as they have reached EOL (@katdom13)
 
 ## [0.2.0] - 2023-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Added support Wagtail 5.1, 5.2 (by @lparsons396, @katdom13)
-- Drop tests for Wagtail 4.2, 5.0 as they have reached EOL (@katdom13)
+- Adapted tests against Wagtail >= 6.0 due to removed `wagtail.contrib.modeladmin`
+- Added tests against Wagtail 5.1, 5.2 (by @lparsons396, @katdom13)
+- Drop tests for Wagtail 4.2, 5.0 and Django 4.1 as they have reached EOL (@katdom13, @th3hamm0r)
 
 ## [0.2.0] - 2023-07-31
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ Integrates [django-admin-rangefilter](https://pypi.org/project/django-admin-rang
 ## Supported versions
 
 - Python 3.8, 3.9, 3.10, 3.11
-- Django 3.2, 4.1, 4.2
-- Wagtail 4.1, 4.2, 5.0, 5.1
+- Django 3.2, 4.2
+- Wagtail 4.1, 5.1, 5.2, 6.0 (with external package [wagtail-modeladmin](https://pypi.org/project/wagtail-modeladmin/))
 
 ## Installation
+
+**NOTE:** Starting with wagtail 5.0 you can install and use the external package [wagtail-modeladmin](https://pypi.org/project/wagtail-modeladmin/), with 6.0+ you have to use it.
 
 ```shell
 pip install wagtail-rangefilter
@@ -39,6 +41,8 @@ INSTALLED_APPS = [
 ## Example usage
 
 ```python
+# Starting with Wagtail 6.0, the external package "wagtail-modeladmin" is required:
+# from wagtail_modeladmin.options import ModelAdmin
 from wagtail.contrib.modeladmin.options import ModelAdmin
 from wagtail_rangefilter.filters import DateRangeFilter, DateTimeRangeFilter
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Integrates [django-admin-rangefilter](https://pypi.org/project/django-admin-rang
 
 - Python 3.8, 3.9, 3.10, 3.11
 - Django 3.2, 4.1, 4.2
-- Wagtail 4.1, 4.2, 5.0
+- Wagtail 4.1, 4.2, 5.0, 5.1
 
 ## Installation
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -22,6 +22,12 @@ ALLOWED_HOSTS = ["*"]
 
 
 # Application definition
+try:
+    import wagtail_modeladmin
+except ImportError:
+    modeladmin_package_name = "wagtail.contrib.modeladmin"
+else:
+    modeladmin_package_name = "wagtail_modeladmin"
 
 INSTALLED_APPS = [
     "tests.testapp",
@@ -38,7 +44,7 @@ INSTALLED_APPS = [
     "wagtail.search",
     "wagtail.admin",
     "wagtail.api.v2",
-    "wagtail.contrib.modeladmin",
+    modeladmin_package_name,
     "wagtail.contrib.routable_page",
     "wagtail.contrib.styleguide",
     "wagtail.sites",

--- a/tests/testapp/wagtail_hooks.py
+++ b/tests/testapp/wagtail_hooks.py
@@ -1,4 +1,7 @@
-from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
+try:
+    from wagtail_modeladmin.options import ModelAdmin, modeladmin_register
+except ImportError:
+    from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 
 from wagtail_rangefilter.filters import DateRangeFilter, DateTimeRangeFilter
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.8,3.9,3.10}-django{3.2,4.1}-wagtail{4.1,4.2,main}-{sqlite,postgres}
-    python{3.11}-django{4.1,4.2}-wagtail{5.0,main}-{sqlite,postgres}
+    python{3.8,3.9,3.10}-django{3.2,4.1}-wagtail{4.1,4.2,5.0,5.1,main}-{sqlite,postgres}
+    python{3.11}-django{4.1,4.2}-wagtail{5.0,5.1,main}-{sqlite,postgres}
     flake8
 
 [flake8]
@@ -42,6 +42,7 @@ deps =
     wagtail4.1: wagtail>=4.1,<4.2
     wagtail4.2: wagtail>=4.2,<5.0
     wagtail5.0: wagtail>=5.0,<5.1
+    wagtail5.1: wagtail>=5.1,<5.2
     wagtailmain: git+https://github.com/wagtail/wagtail.git
 
     postgres: psycopg2>=2.6

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,9 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.8,3.9,3.10}-django{3.2,4.1}-wagtail{4.1,4.2,5.0,5.1,main}-{sqlite,postgres}
-    python{3.11}-django{4.1,4.2}-wagtail{5.0,5.1,main}-{sqlite,postgres}
+    python{3.8,3.9,3.10}-django{3.2,4.1}-wagtail{4.1,5.1,5.2}-{sqlite,postgres}
+    python3.11-django4.1-wagtail{4.1,5.1,5.2}-{sqlite,postgres}
+    python3.11-django4.2-wagtail{5.1,5.2}-{sqlite,postgres}
     flake8
 
 [flake8]
@@ -43,6 +44,8 @@ deps =
     wagtail4.2: wagtail>=4.2,<5.0
     wagtail5.0: wagtail>=5.0,<5.1
     wagtail5.1: wagtail>=5.1,<5.2
+
+    ; The current Wagtail version for main is 5.1.x, which is deprecates the wagtail.contrib.modeladmin module
     wagtailmain: git+https://github.com/wagtail/wagtail.git
 
     postgres: psycopg2>=2.6

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,8 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.8,3.9,3.10}-django{3.2,4.1}-wagtail{4.1,5.1,5.2}-{sqlite,postgres}
-    python3.11-django4.1-wagtail{4.1,5.1,5.2}-{sqlite,postgres}
-    python3.11-django4.2-wagtail{5.1,5.2}-{sqlite,postgres}
+    python{3.8,3.9,3.10,3.11}-django3.2-wagtail{4.1,5.1,5.2,main}-{sqlite,postgres}
+    python3.11-django4.2-wagtail{5.1,5.2,main}-{sqlite,postgres}
     flake8
 
 [flake8]
@@ -34,19 +33,18 @@ deps =
     coverage
 
     django3.2: Django>=3.2,<4.0
-    django4.1: Django>=4.1,<4.2
     django4.2: Django>=4.2,<4.3
 
     ; The current Django version for main is 5.x, which is not supported by any Wagtail versions yet
     djangomain: git+https://github.com/django/django.git@main#egg=Django
 
     wagtail4.1: wagtail>=4.1,<4.2
-    wagtail4.2: wagtail>=4.2,<5.0
-    wagtail5.0: wagtail>=5.0,<5.1
     wagtail5.1: wagtail>=5.1,<5.2
+    wagtail5.2: wagtail>=5.2,<5.3
 
-    ; The current Wagtail version for main is 5.1.x, which is deprecates the wagtail.contrib.modeladmin module
+    ; Starting with wagtail 6.0 the wagtail.contrib.modeladmin module has been removed.
     wagtailmain: git+https://github.com/wagtail/wagtail.git
+    wagtailmain: wagtail-modeladmin
 
     postgres: psycopg2>=2.6
 


### PR DESCRIPTION
This is based on the PRs https://github.com/wunderweiss/wagtail-rangefilter/pull/3 and https://github.com/wunderweiss/wagtail-rangefilter/pull/5.

Adaptions:
* drop testing for Django 4.1 (EOL soon)
* fixed tests for Wagtail >=6
* changed wording of the changelog, since those changes just improve the test coverage, no functional changes
* added notes to the README, that Wagtail >= 6 requires the external package [wagtail-modeladmin](https://pypi.org/project/wagtail-modeladmin/)