### PR TITLE
Checks for wagtail 6.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Drop tests for Django < 4.2 as it has reached EOL (@katdom13)
 - Add tests for Python 3.12 (@katdom13)
 - Add `wagtail-modeladmin` to testing dependencies (@katdom13)
+- Add python 3.13 to testing matrix
 
 ## [0.2.1] - 2024-02-07
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Integrates [django-admin-rangefilter](https://pypi.org/project/django-admin-rang
 
 ## Supported versions
 
-- Python 3.9, 3.10, 3.11, 3.12
-- Django 4.2, 5.0
-- Wagtail 5.2, 6.0, 6.1 (with external package [wagtail-modeladmin](https://pypi.org/project/wagtail-modeladmin/))
+- Python 3.9, 3.10, 3.11, 3.12, 3.13
+- Django 4.2, 5.0, 5.1
+- Wagtail 5.2, 6.0, 6.1, 6.2, 6.3 (with external package [wagtail-modeladmin](https://pypi.org/project/wagtail-modeladmin/))
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Integrates [django-admin-rangefilter](https://pypi.org/project/django-admin-rang
 
 ## Supported versions
 
-- Python 3.9, 3.10, 3.11
+- Python 3.9, 3.10, 3.11, 3.12
 - Django 4.2, 5.0
 - Wagtail 5.2, 6.0, 6.1 (with external package [wagtail-modeladmin](https://pypi.org/project/wagtail-modeladmin/))
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Integrates [django-admin-rangefilter](https://pypi.org/project/django-admin-rang
 
 ## Supported versions
 
-- Python 3.8, 3.9, 3.10, 3.11, 3.12
+- Python 3.9, 3.10, 3.11
 - Django 4.2, 5.0
 - Wagtail 5.2, 6.0, 6.1 (with external package [wagtail-modeladmin](https://pypi.org/project/wagtail-modeladmin/))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,13 +31,12 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "django-admin-rangefilter>=0.12",
     "Django>=4.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Framework :: Django",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",
@@ -35,6 +36,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 requires-python = ">=3.9"
 dependencies = [

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,9 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.0,6.1,6.2}
-    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.0,6.1,6.2}
+    python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.0,6.1,6.2,6.3}
+    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.0,6.1,6.2,6.3}
+    python{3.10,3.11,3.12}-django5.1-wagtail{6.3}
     flake8
 
 [flake8]
@@ -34,12 +35,14 @@ deps =
 
     django4.2: Django>=4.2,<4.3
     django5.0: Django>=5.0,<5.1
+    django5.1: Django>=5.1,<5.2
     djangomain: git+https://github.com/django/django.git@main#egg=Django
 
     wagtail5.2: wagtail>=5.2,<5.3
     wagtail6.0: wagtail>=6.0,<6.1
     wagtail6.1: wagtail>=6.1,<6.2
     wagtail6.2: wagtail>=6.2,<6.3
+    wagtail6.3: wagtail>=6.3,<6.4
     wagtailmain: git+https://github.com/wagtail/wagtail.git
 
     postgres: psycopg2>=2.6

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.8,3.9,3.10,3.11}-django4.2-wagtail{5.2,6.0,6.1,6.2}
+    python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.0,6.1,6.2}
     python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.0,6.1,6.2}
     flake8
 
@@ -24,7 +24,6 @@ commands =
     coverage report -m
 
 basepython =
-    python3.8: python3.8
     python3.9: python3.9
     python3.10: python3.10
     python3.11: python3.11
@@ -67,7 +66,6 @@ commands=flake8 src/wagtail_rangefilter tests/
 
 [gh-actions]
 python =
-    3.8: python3.8
     3.9: python3.9
     3.10: python3.10
     3.11: python3.11

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ usedevelop = True
 envlist =
     python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.0,6.1,6.2,6.3}
     python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.0,6.1,6.2,6.3}
-    python{3.10,3.11,3.12}-django5.1-wagtail{6.3}
+    python{3.10,3.11,3.12,3,13}-django5.1-wagtail{6.3}
     flake8
 
 [flake8]
@@ -29,6 +29,7 @@ basepython =
     python3.10: python3.10
     python3.11: python3.11
     python3.12: python3.12
+    python3.13: python3.13
 
 deps =
     coverage
@@ -73,6 +74,7 @@ python =
     3.10: python3.10
     3.11: python3.11
     3.12: python3.12
+    3.13: python3.13
 
 [gh-actions:env]
 DB_BACKEND =


### PR DESCRIPTION
This pull request includes updates to the supported Python versions and dependencies

Updates to supported Python versions:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L18-R18): Removed Python 3.8 from the matrix of supported versions. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L18-R18) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L42-R42)
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R19): Updated the list of supported Python versions to remove Python 3.8.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L34-R39): Removed Python 3.8 from the classifiers and updated the `requires-python` field to `>=3.9`.
* [`tox.ini`](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449L6-R8): Removed Python 3.8 from the `envlist` and `basepython` sections. [[1]](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449L6-R8) [[2]](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449L27) [[3]](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449L70)

Updates to dependencies:

* [`tox.ini`](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449L6-R8): Added support for Django 5.1 and Wagtail 6.3. [[1]](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449L6-R8) [[2]](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449R38-R45)

Questions:

- Did you want me to add python 3.13 into the mix?