### PR TITLE
Wagtail 64 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Integrates [django-admin-rangefilter](https://pypi.org/project/django-admin-rang
 
 - Python 3.9, 3.10, 3.11, 3.12, 3.13
 - Django 4.2, 5.0, 5.1
-- Wagtail 5.2, 6.0, 6.1, 6.2, 6.3 (with external package [wagtail-modeladmin](https://pypi.org/project/wagtail-modeladmin/))
+- Wagtail 5.2, 6.0, 6.1, 6.2, 6.3, 6.4 (with external package [wagtail-modeladmin](https://pypi.org/project/wagtail-modeladmin/))
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
 testing = [
     "coverage~=7.5.1",
     "tox~=4.15.0",
-    "wagtail-modeladmin==2.0.0",
+    "wagtail-modeladmin~=2.1",
 ]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,9 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.0,6.1,6.2,6.3}
-    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.0,6.1,6.2,6.3}
-    python{3.10,3.11,3.12,3,13}-django5.1-wagtail{6.3}
+    python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.0,6.1,6.2,6.3,6.4}
+    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.0,6.1,6.2,6.3,6.4}
+    python{3.10,3.11,3.12,3,13}-django5.1-wagtail{6.3.6.4}
     flake8
 
 [flake8]
@@ -44,6 +44,7 @@ deps =
     wagtail6.1: wagtail>=6.1,<6.2
     wagtail6.2: wagtail>=6.2,<6.3
     wagtail6.3: wagtail>=6.3,<6.4
+    wagtail6.4: wagtail>=6.4,<6.5
     wagtailmain: git+https://github.com/wagtail/wagtail.git
 
     postgres: psycopg2>=2.6

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ usedevelop = True
 envlist =
     python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.0,6.1,6.2,6.3,6.4}
     python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.0,6.1,6.2,6.3,6.4}
-    python{3.10,3.11,3.12,3,13}-django5.1-wagtail{6.3.6.4}
+    python{3.10,3.11,3.12,3,13}-django5.1-wagtail{6.3,6.4}
     flake8
 
 [flake8]


### PR DESCRIPTION
This pull request includes updates to dependencies and test environments to support new versions of Wagtail.

Dependency updates:

* Updated `wagtail-modeladmin` dependency to version `~2.1` in `pyproject.toml`.

Test environment updates:

* Added Wagtail version `6.4` to the test environments in `tox.ini` for various Python and Django versions.
* Added Wagtail version `6.4` to the dependency list in `tox.ini`.