### PR TITLE
Wagtail 7.1 maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Wagtail 7.1 maintenance
+
+- Add tox testing for Wagtail 7.1
+
 Wagtail 7.0 maintenance
 
 - Add tox testing for Wagtail 7.0 & Django 5.2

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Integrates [django-admin-rangefilter](https://pypi.org/project/django-admin-rang
 
 - Python 3.9, 3.10, 3.11, 3.12, 3.13
 - Django 4.2, 5.1, 5.2
-- Wagtail 5.2, 6.3, 6.4, 7.0 (with external package [wagtail-modeladmin](https://pypi.org/project/wagtail-modeladmin/))
+- Wagtail 5.2, 6.3, 6.4, 7.0, 7.1 (with external package [wagtail-modeladmin](https://pypi.org/project/wagtail-modeladmin/))
 
 ## Installation
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.3,6.4,7.0}
-    python{3.10,3.11,3.12,3,13}-django{5.1,5.2}-wagtail{6.3,6.4,7.0}
+    python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.3,6.4,7.0,7.1}
+    python{3.10,3.11,3.12,3,13}-django{5.1,5.2}-wagtail{6.3,6.4,7.0,7.1}
     flake8
 
 [flake8]
@@ -42,6 +42,7 @@ deps =
     wagtail6.3: wagtail>=6.3,<6.4
     wagtail6.4: wagtail>=6.4,<6.5
     wagtail7.0: wagtail>=7.0,<7.1
+    wagtail7.1: wagtail>=7.1,<7.2
     wagtailmain: git+https://github.com/wagtail/wagtail.git
 
     postgres: psycopg2>=2.6


### PR DESCRIPTION
This pull request updates the test matrix in `tox.ini` to add support for Wagtail 7.1 across multiple Python and Django versions. The most important changes are grouped below:

**Test matrix updates:**

* Added `wagtail7.1` to the `envlist`, expanding test coverage to include Wagtail 7.1 for Python and Django combinations.

**Dependency configuration:**

* Defined a new dependency group `wagtail7.1` to install `wagtail>=7.1,<7.2`, ensuring tests run against the correct Wagtail version.