### PR TITLE
Wagtail 7.2 maintenance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Wagtail 7.2 maintenance
+
+- Add tox testing for Wagtail 7.2
+- Drop tests for Wagtail 5.2 as it has reached EOL
+- Add tests for Python 3.14
+- Drop tests for Python 3.9 as it has reached EOL
+
 Wagtail 7.0 maintenance
 
 - Add tox testing for Wagtail 7.0 & Django 5.2

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Integrates [django-admin-rangefilter](https://pypi.org/project/django-admin-rang
 
 ## Supported versions
 
-- Python 3.9, 3.10, 3.11, 3.12, 3.13
+- Python 3.10, 3.11, 3.12, 3.13, 3.14
 - Django 4.2, 5.1, 5.2
-- Wagtail 5.2, 6.3, 6.4, 7.0 (with external package [wagtail-modeladmin](https://pypi.org/project/wagtail-modeladmin/))
+- Wagtail 6.3, 7.0, 7.2 (with external package [wagtail-modeladmin](https://pypi.org/project/wagtail-modeladmin/))
 
 ## Installation
 
-**NOTE:** Starting with wagtail 5.2 you can install and use the external package [wagtail-modeladmin](https://pypi.org/project/wagtail-modeladmin/), with 6.3+ you have to use it.
+**NOTE:** Starting with wagtail 6.3 you have to use the external package [wagtail-modeladmin](https://pypi.org/project/wagtail-modeladmin/).
 
 ```shell
 pip install wagtail-rangefilter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
     "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",
     "Framework :: Wagtail :: 7",
     "Intended Audience :: Developers",
@@ -33,24 +32,24 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "django-admin-rangefilter>=0.12",
     "Django>=4.2",
-    "wagtail>=5.2",
+    "wagtail>=6.3",
 ]
 
 [project.optional-dependencies]
 testing = [
     "coverage~=7.5.1",
     "tox~=4.15.0",
-    "wagtail-modeladmin~=2.1",
+    "wagtail-modeladmin~=2.2",
 ]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,9 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.3,6.4,7.0}
-    python{3.10,3.11,3.12,3,13}-django{5.1,5.2}-wagtail{6.3,6.4,7.0}
+    python{3.10,3.11,3.12}-django4.2-wagtail{6.3,7.0,7.2}
+    python{3.10,3.11,3.12,3,13}-django{5.1,5.2}-wagtail{6.3,7.0,7.2}
+    python3.14-django5.2-wagtail7.2
     flake8
 
 [flake8]
@@ -24,11 +25,11 @@ commands =
     coverage report -m
 
 basepython =
-    python3.9: python3.9
     python3.10: python3.10
     python3.11: python3.11
     python3.12: python3.12
     python3.13: python3.13
+    python3.14: python3.14
 
 deps =
     coverage
@@ -38,10 +39,9 @@ deps =
     django5.2: Django>=5.2,<5.3
     djangomain: git+https://github.com/django/django.git@main#egg=Django
 
-    wagtail5.2: wagtail>=5.2,<5.3
     wagtail6.3: wagtail>=6.3,<6.4
-    wagtail6.4: wagtail>=6.4,<6.5
     wagtail7.0: wagtail>=7.0,<7.1
+    wagtail7.2: wagtail>=7.2,<7.3
     wagtailmain: git+https://github.com/wagtail/wagtail.git
 
     postgres: psycopg2>=2.6
@@ -68,11 +68,11 @@ commands=flake8 src/wagtail_rangefilter tests/
 
 [gh-actions]
 python =
-    3.9: python3.9
     3.10: python3.10
     3.11: python3.11
     3.12: python3.12
     3.13: python3.13
+    3.14: python3.14
 
 [gh-actions:env]
 DB_BACKEND =


### PR DESCRIPTION
This pull request updates the supported Python and Wagtail versions across the project, removing support for older versions and adding compatibility with the latest releases. 

**Supported versions and documentation updates:**

* Updated `README.md` to indicate support for Python 3.10–3.14 and Wagtail 6.3, 7.0, and 7.2, and clarified that the external package `wagtail-modeladmin` is required starting from Wagtail 6.3.

**Testing and CI configuration:**

* Updated `.github/workflows/test.yml` to test against Python 3.10–3.14, removing Python 3.9 from the matrix. 
* Modified `tox.ini` to remove Python 3.9 and older Wagtail versions from the test environments, add Python 3.14 and Wagtail 7.2, and update dependency versions for `wagtail-modeladmin`. 

**Packaging and dependency updates:**

* Updated `pyproject.toml` to require Python >=3.10, add Python 3.14 to classifiers, require Wagtail >=6.3, and update optional dependencies for `wagtail-modeladmin`.