### PR TITLE
Wagtail 7.4 Maintenance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -42,7 +42,7 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Wagtail 7.4 maintenance
 - Add tox testing for Wagtail 7.3 and Wagtail 7.4 LTS
 - Add tox testing for Django 6.0
 - Drop tests for Wagtail 6.3 as the new previous LTS is now Wagtail 7.0
-- Drop tests for Django 5.1 as it has reached EOL
+- Drop tests for Django 4.2 and 5.1 as they have reached EOL
 - Bump testing dependency `wagtail-modeladmin` to `~=2.3`
 - Bump production dependency `django-admin-rangefilter` to `>=0.13`
 - Remove deprecated `default_app_config` from package and tests (removed in Django 5.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Wagtail 7.4 maintenance
+
+- Add tox testing for Wagtail 7.3 and Wagtail 7.4 LTS
+- Add tox testing for Django 6.0
+- Drop tests for Wagtail 6.3 as the new previous LTS is now Wagtail 7.0
+- Drop tests for Django 5.1 as it has reached EOL
+- Bump testing dependency `wagtail-modeladmin` to `~=2.3`
+- Bump production dependency `django-admin-rangefilter` to `>=0.13`
+- Remove deprecated `default_app_config` from package and tests (removed in Django 5.0)
+- Remove deprecated `USE_L10N` setting from test settings (removed in Django 5.0)
+- Remove residual Python 2 `str()` wrapper around dynamic form class name
+- Bump `actions/checkout` to v5 in CI workflow
+
 Wagtail 7.2 maintenance
 
 - Add tox testing for Wagtail 7.2

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ Integrates [django-admin-rangefilter](https://pypi.org/project/django-admin-rang
 ## Supported versions
 
 - Python 3.10, 3.11, 3.12, 3.13, 3.14
-- Django 4.2, 5.1, 5.2
-- Wagtail 6.3, 7.0, 7.2 (with external package [wagtail-modeladmin](https://pypi.org/project/wagtail-modeladmin/))
+- Django 4.2, 5.2, 6.0
+- Wagtail 7.0, 7.2, 7.3, 7.4 (with external package [wagtail-modeladmin](https://pypi.org/project/wagtail-modeladmin/))
 
 ## Installation
 
-**NOTE:** Starting with wagtail 6.3 you have to use the external package [wagtail-modeladmin](https://pypi.org/project/wagtail-modeladmin/).
+**NOTE:** Starting with Wagtail 6.3 you have to use the external package [wagtail-modeladmin](https://pypi.org/project/wagtail-modeladmin/).
 
 ```shell
 pip install wagtail-rangefilter

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Integrates [django-admin-rangefilter](https://pypi.org/project/django-admin-rang
 ## Supported versions
 
 - Python 3.10, 3.11, 3.12, 3.13, 3.14
-- Django 4.2, 5.2, 6.0
+- Django 5.2, 6.0
 - Wagtail 7.0, 7.2, 7.3, 7.4 (with external package [wagtail-modeladmin](https://pypi.org/project/wagtail-modeladmin/))
 
 ## Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dynamic = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Framework :: Django",
-    "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.2",
     "Framework :: Django :: 6.0",
     "Framework :: Wagtail",
@@ -40,7 +39,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "django-admin-rangefilter>=0.13",
-    "Django>=4.2",
+    "Django>=5.2",
     "wagtail>=7.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,9 @@ dependencies = [
 
 [project.optional-dependencies]
 testing = [
-    "coverage~=7.5.1",
-    "tox~=4.15.0",
-    "wagtail-modeladmin~=2.2",
+    "coverage~=7.5",
+    "tox~=4.15",
+    "wagtail-modeladmin~=2.3",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,9 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 6",
     "Framework :: Wagtail :: 7",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
@@ -40,9 +39,9 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "django-admin-rangefilter>=0.12",
+    "django-admin-rangefilter>=0.13",
     "Django>=4.2",
-    "wagtail>=6.3",
+    "wagtail>=7.0",
 ]
 
 [project.optional-dependencies]

--- a/src/wagtail_rangefilter/__init__.py
+++ b/src/wagtail_rangefilter/__init__.py
@@ -1,5 +1,2 @@
-default_app_config = "wagtail_rangefilter.apps.WagtailRangefilterAppConfig"
-
-
 VERSION = (0, 2, 1)
 __version__ = ".".join(map(str, VERSION))

--- a/src/wagtail_rangefilter/filters.py
+++ b/src/wagtail_rangefilter/filters.py
@@ -15,9 +15,7 @@ class WagtailDateRangeMixin:
 
     def _get_form_class(self: BaseDateRangeFilter):
         fields = self._get_form_fields()
-        form_class = type(
-            str("DateRangeForm"), (forms.BaseForm,), {"base_fields": fields}
-        )
+        form_class = type("DateRangeForm", (forms.BaseForm,), {"base_fields": fields})
         return form_class
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "tests.apps.WagtailRangefilterTestAppConfig"

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -146,8 +146,6 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.10,3.11,3.12}-django4.2-wagtail{7.0,7.2,7.3}
     python{3.10,3.11,3.12,3.13}-django5.2-wagtail7.0
     python{3.10,3.11,3.12,3.13,3.14}-django5.2-wagtail{7.2,7.3,7.4}
     python{3.12,3.13,3.14}-django6.0-wagtail{7.3,7.4}
@@ -35,7 +34,6 @@ basepython =
 deps =
     coverage
 
-    django4.2: Django>=4.2,<4.3
     django5.2: Django>=5.2,<5.3
     django6.0: Django>=6.0,<6.1
     djangomain: git+https://github.com/django/django.git@main#egg=Django

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,10 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.10,3.11,3.12}-django4.2-wagtail{6.3,7.0,7.2}
-    python{3.10,3.11,3.12,3,13}-django{5.1,5.2}-wagtail{6.3,7.0,7.2}
-    python3.14-django5.2-wagtail7.2
+    python{3.10,3.11,3.12}-django4.2-wagtail{7.0,7.2,7.3}
+    python{3.10,3.11,3.12,3.13}-django5.2-wagtail7.0
+    python{3.10,3.11,3.12,3.13,3.14}-django5.2-wagtail{7.2,7.3,7.4}
+    python{3.12,3.13,3.14}-django6.0-wagtail{7.3,7.4}
     flake8
 
 [flake8]
@@ -35,13 +36,14 @@ deps =
     coverage
 
     django4.2: Django>=4.2,<4.3
-    django5.1: Django>=5.1,<5.2
     django5.2: Django>=5.2,<5.3
+    django6.0: Django>=6.0,<6.1
     djangomain: git+https://github.com/django/django.git@main#egg=Django
 
-    wagtail6.3: wagtail>=6.3,<6.4
     wagtail7.0: wagtail>=7.0,<7.1
     wagtail7.2: wagtail>=7.2,<7.3
+    wagtail7.3: wagtail>=7.3,<7.4
+    wagtail7.4: wagtail>=7.4,<7.5
     wagtailmain: git+https://github.com/wagtail/wagtail.git
 
     postgres: psycopg2>=2.6


### PR DESCRIPTION
## Summary

Extend the supported version window to cover the new Wagtail 7.4 LTS and drop versions that are no longer in their support windows.

- **Wagtail**: drop 6.3; support 7.0 LTS, 7.2, 7.3, 7.4 LTS (previous LTS is now 7.0).
- **Django**: drop **4.2 and 5.1** (both EOL April 2026); add 6.0. Final supported set: 5.2, 6.0.
- **Python**: 3.10–3.14 (unchanged).
- Bump `django-admin-rangefilter` to `>=0.13` and `wagtail-modeladmin` testing extra to `~=2.3`.
- Remove deprecated `default_app_config` (removed in Django 5.0) from package and tests.
- Remove deprecated `USE_L10N` setting from test settings (removed in Django 5.0).
- Remove the residual Python 2 `str()` wrapper around the dynamic form class name.
- Rebuild the tox matrix; fix the `3,13` typo in the env list.
- Bump `actions/checkout` to `v5` in CI.

### Note on dropping Django 4.2

Django 4.2 was also dropped because `wagtail-modeladmin 2.3.0` is broken on Django < 5.0: `views.py` sets `self.params = request.GET.dict()` (a plain `dict`) for Django < 5, but `get_filters_params` later calls `dict(params.lists())` — `dict` has no `.lists()`, so every `IndexView` request raises `AttributeError`. The bug is also present on current upstream `main`, and `wagtail-modeladmin` is officially in maintenance mode, so dropping the EOL Django version is the pragmatic resolution.

## Test plan

- [ ] CI passes across the new tox matrix (sqlite + postgres jobs, Python 3.10–3.14).
- [ ] `tox -e python3.12-django6.0-wagtail7.4` passes locally.
- [ ] `tox -e python3.12-django5.2-wagtail7.3` passes locally.
- [ ] `tox -e flake8` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)